### PR TITLE
status.go: Update status struct

### DIFF
--- a/status.go
+++ b/status.go
@@ -10,12 +10,12 @@ import (
 // status.go function.
 type Status struct {
 	// TODO: The Status structure is still a work in progress
-	Fullscreen    bool              `json:"fullscreen"`
+	Fullscreen    uint              `json:"fullscreen"`
 	Stats         Stats             `json:"stats"`
 	AspectRatio   string            `json:"aspectratio"`
 	AudioDelay    float64           `json:"audiodelay"`
 	APIVersion    uint              `json:"apiversion"`
-	CurrentPlID   uint              `json:"currentplid"`
+	CurrentPlID   int               `json:"currentplid"`
 	Time          uint              `json:"time"`
 	Volume        uint              `json:"volume"`
 	Length        uint              `json:"length"`
@@ -30,7 +30,7 @@ type Status struct {
 	Information   Information       `json:"information"`
 	Repeat        bool              `json:"repeat"`
 	SubtitleDelay float64           `json:"subtitledelay"`
-	Equalizer     Equalizer         `json:"equalizer"`
+	Equalizer     []Equalizer       `json:"equalizer"`
 }
 
 // Stats contains certain statistics of a VLC instance. A Stats variable is included in Status


### PR DESCRIPTION
The latest version (3.0.17.4) of VLC's status.json looks like this:
```json
{
  "fullscreen":0,
  "audiodelay":0,
  "apiversion":3,
  "currentplid":-1,
  "time":0,
  "volume":256,
  "length":0,
  "random":false,
  "audiofilters":{
    "filter_0":""
  },
  "rate":1,
  "videoeffects":{
    "hue":0,
    "saturation":1,
    "contrast":1,
    "brightness":1,
    "gamma":1
  },
  "state":"stopped",
  "loop":false,
  "version":"3.0.17.4 Vetinari",
  "position":0,
  "repeat":false,
  "subtitledelay":0,
  "equalizer":[]
}
```

The original Status structure definition was no longer able to parse the current JSON format, so I made the following changes:

- `fullscreen` is no longer a bool value, so change its type to uint.
- `currentplid` may have a negative number, so change its type to int.
- `equalizer` is an array, so change its type to array.